### PR TITLE
Fix/deprecation

### DIFF
--- a/src/CSVasTable/widget/CSVasTable.js
+++ b/src/CSVasTable/widget/CSVasTable.js
@@ -59,7 +59,7 @@ define([
             this._handles = [];
         },
 
-        log() {
+        log: function() {
             var args = Array.prototype.slice.call(arguments);
             if (this.id) {
                 args.unshift(this.id);


### PR DESCRIPTION
Function was written using ES6 style, while Mx 7 and 8 should be compatible with ES5. My bad.